### PR TITLE
Adding dropdown and selection option on each cell of S column

### DIFF
--- a/teste_cursorium2/src/board/components/InputTable/InputTable.tsx
+++ b/teste_cursorium2/src/board/components/InputTable/InputTable.tsx
@@ -1,6 +1,7 @@
-import "./styles/InputTable.css"
-import { DataGrid, GridColDef } from '@mui/x-data-grid';
-import { useState } from 'react';
+import { MenuItem, Select } from "@mui/material";
+import "./styles/InputTable.css";
+import { DataGrid, GridColDef, GridRowId } from '@mui/x-data-grid';
+import { useState, useEffect } from 'react';
 
 type Row = {
   id: number;
@@ -11,14 +12,14 @@ type Row = {
 
 export default function DataTable() {
 
-  var initialLetters = ['A','B','C'];
-  var initialOutput = [0,0,0,0,0,0,0,0];
+  const initialLetters = ['A', 'B', 'C'];
+  const initialOutput = [0, 0, 0, 1, 0, 0, 0, 0];
 
-  const [letters,setLetters] = useState(initialLetters);
-  const [output,setOutput] = useState(initialOutput);
+  const [letters, setLetters] = useState(initialLetters);
+  const [output, setOutput] = useState(initialOutput);
 
-  if((Math.pow(2,letters.length))!== output.length){
-    throw new Error(`Erro, tamanho do vetor de saída (${output.length}) não bate com quantidade de variáveis (${Math.pow(2,letters.length)})`);
+  if ((Math.pow(2, letters.length)) !== output.length) {
+    throw new Error(`Error: output length (${output.length}) does not match the number of variables (${Math.pow(2, letters.length)})`);
   }
 
   const columns: GridColDef[] = letters.map((letter) => ({
@@ -26,39 +27,60 @@ export default function DataTable() {
     headerName: letter,
     flex: 1,
     editable: false,
-    headerClassName:'GridColumnHeader',
-    headerAlign:'center', 
+    headerClassName: 'GridColumnHeader',
+    headerAlign: 'center',
   }));
 
   function decimalToBinary(N: number) {
-    return (N >>> 0).toString(2).padStart(letters.length, '0');;
+    return (N >>> 0).toString(2).padStart(letters.length, '0');
   }
-  
-  function columnsForTheRows(index:number){
-    var binary = decimalToBinary(index);
 
-    const columnValues = columns.reduce((acc, column, idx) => {
+  function columnsForTheRows(index: number) {
+    const binary = decimalToBinary(index);
+
+    return columns.reduce((acc, column, idx) => {
       acc[column.field] = binary[idx] || '0';
       return acc;
     }, {} as { [key: string]: string });
-
-    return columnValues;
   }
 
-  columns.push({ 
-    field: 'S', 
-    headerName: 'S', 
-    flex: 1, 
-    editable: true, 
-    headerClassName:'GridColumnHeader',
-    headerAlign:'center' 
-  });  
+  const handleStatusChange = (id: GridRowId, newStatus: string) => {
+    setRows((prevRows) =>
+      prevRows.map((row) => (row.id === id ? { ...row, S: newStatus } : row))
+    );
+  };
+
+  columns.push({
+    field: 'S',
+    headerName: 'S',
+    flex: 1,
+    headerClassName: 'GridColumnHeader',
+    headerAlign: 'center',
+    renderCell: (params) => (
+      <Select
+        value={params.value}
+        onChange={(e) => handleStatusChange(params.id, e.target.value)}
+        className="cellSelector"
+        fullWidth
+        MenuProps={{
+          classes: { paper: 'menu' },
+        }}
+      >
+        <MenuItem key={0} value={'0'} className="menuItem">
+          {'0'}
+        </MenuItem>
+        <MenuItem key={1} value={'1'} className="menuItem">
+          {'1'}
+        </MenuItem>
+      </Select>
+    ),
+  });
 
   const [rows, setRows] = useState<Row[]>(
     output.map((result, index) => ({
       id: index,
       ...columnsForTheRows(index),
-      S: result.toString(), // Ensure 'S' field is a string for consistency
+      S: result.toString(),
     }))
   );
 
@@ -73,8 +95,8 @@ export default function DataTable() {
         disableColumnMenu
         disableColumnResize
         disableColumnSorting
-        className='InputTable'
-        />
+        className="InputTable"
+      />
     </div>
   );
 }

--- a/teste_cursorium2/src/board/components/InputTable/styles/InputTable.css
+++ b/teste_cursorium2/src/board/components/InputTable/styles/InputTable.css
@@ -29,6 +29,44 @@
     color: var(--rp-text) !important;
 }
 
+.cellSelector, .menuItem{
+    color: var(--rp-text)! important;
+    width: 100%;
+    border: none !important;
+    font-family: 'Jebrains', sans-serif !important;
+    font-size: 1.5rem !important;
+    align-items: center !important;
+    text-align: center !important;
+}
+
+.cellSelector .MuiSelect-icon {
+    display: none;
+}
+
+.cellSelector .MuiOutlinedInput-notchedOutline {
+    border: none;
+}
+
+.cellSelector > div {
+    padding: 0px !important
+}
+
+.menu{
+    background-color: var(--rp-surface) !important;
+    text-align: center !important;
+    min-width: min-content !important;
+}
+
+.menuItem{
+    background-color: var(--rp-surface) !important;
+    text-align: center !important;
+    width: min-content !important;
+}
+
+.menuItem:hover, .cellSelector:hover{
+    background-color: var(--rp-overlay) !important;
+}
+
 @media screen and (max-width:500px) {
     .GridColumnHeader{
         font-size: 1rem;


### PR DESCRIPTION
# Add Selection option to each cell in S column
Since it got too hard to filter the user input on the cells in `S` column (mostly because MUI Table grid sucks) I thought it would be better to limit the user to a dropdown, with only 0 and 1 as an option; 

- Added `Select` from MUI Materials to each cell in the `S` column;
- Added one `MenuItem` from MUI Materials for each option (0 and 1);
- Added the needed `CSS` for each new item;
## UI Changes:
![screen-recorder-sat-jun-29-2024-20-26-39-ezgif com-video-to-gif-converter](https://github.com/gckneip/cursorium2/assets/161786020/f8330eb5-5b4c-4abe-84cf-105e5067ecb8)

Resolves: #9 
